### PR TITLE
@aleien, Манюхина

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,6 +92,8 @@ dependencies {
     compile libraries.supportDesign
     compile libraries.supportRecyclerView
     compile libraries.supportCardView
+    compile libraries.constraintLayout
+    compile libraries.flexboxLayout
 
     compile libraries.butterKnife
     apt libraries.butterKnifeCompiler
@@ -104,6 +106,7 @@ dependencies {
     compile libraries.tinyDancer
     compile libraries.lynx
     compile libraries.processPhoenix
+    compile libraries.viewServer
 
     testCompile libraries.junit
     testCompile libraries.robolectric

--- a/app/src/main/java/ru/yandex/yamblz/ui/activities/MainActivity.java
+++ b/app/src/main/java/ru/yandex/yamblz/ui/activities/MainActivity.java
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 
+import com.android.debug.hv.ViewServer;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -24,6 +26,8 @@ public class MainActivity extends BaseActivity {
         super.onCreate(savedInstanceState);
         App.get(this).applicationComponent().inject(this);
 
+        ViewServer.get(this).addWindow(this);
+
         setContentView(viewModifier.modify(getLayoutInflater().inflate(R.layout.activity_main, null)));
 
         if (savedInstanceState == null) {
@@ -32,5 +36,15 @@ public class MainActivity extends BaseActivity {
                     .replace(R.id.main_frame_layout, new ContentFragment())
                     .commit();
         }
+    }
+
+    public void onDestroy() {
+        super.onDestroy();
+        ViewServer.get(this).removeWindow(this);
+    }
+
+    public void onResume() {
+        super.onResume();
+        ViewServer.get(this).setFocusedWindow(this);
     }
 }

--- a/app/src/main/res/layout/constraint_layout.xml
+++ b/app/src/main/res/layout/constraint_layout.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    tools:ignore="ContentDescription,RtlHardcoded">
+
+    <!-- INFERRED CONSTRAINTS -->
+
+    <ImageView
+        style="@style/Item.00"
+        android:layout_width="96dp"
+        android:layout_height="96dp"
+        android:id="@+id/imageView12" />
+
+    <ImageView
+        android:id="@+id/imageView9"
+        style="@style/Item.01"
+        android:layout_width="96dp"
+        android:layout_height="96dp"
+        android:layout_marginEnd="96dp"
+        android:layout_marginLeft="96dp"
+        android:layout_marginRight="96dp"
+        android:layout_marginStart="96dp"
+        app:layout_constraintRight_toRightOf="@+id/imageView11"
+        tools:layout_constraintLeft_creator="1"
+        tools:layout_constraintRight_creator="1"
+        tools:layout_editor_absoluteX="96dp" />
+
+    <ImageView
+        android:id="@+id/imageView11"
+        style="@style/Item.02"
+        android:layout_width="96dp"
+        android:layout_height="96dp"
+        android:layout_marginEnd="96dp"
+        android:layout_marginLeft="96dp"
+        android:layout_marginRight="96dp"
+        android:layout_marginStart="96dp"
+        app:layout_constraintLeft_toRightOf="@id/imageView12"
+        tools:layout_constraintLeft_creator="1"
+        tools:layout_constraintRight_creator="1"
+        tools:layout_editor_absoluteX="192dp" />
+
+    <ImageView
+        android:id="@+id/imageView10"
+        style="@style/Item.10"
+        android:layout_width="96dp"
+        android:layout_height="96dp"
+        app:layout_constraintBottom_toBottomOf="@+id/imageView7"
+        app:layout_constraintRight_toRightOf="@id/imageView12"
+        app:layout_constraintTop_toBottomOf="@id/imageView12"
+        tools:layout_constraintBottom_creator="1"
+        tools:layout_constraintLeft_creator="1"
+        tools:layout_constraintRight_creator="1"
+        tools:layout_constraintTop_creator="1"
+        tools:layout_editor_absoluteX="0dp"
+        tools:layout_editor_absoluteY="96dp" />
+
+    <ImageView
+        android:id="@id/imageView7"
+        style="@style/Item.11"
+        android:layout_width="96dp"
+        android:layout_height="96dp"
+        app:layout_constraintLeft_toLeftOf="@id/imageView9"
+        app:layout_constraintRight_toRightOf="@id/imageView9"
+        app:layout_constraintTop_toBottomOf="@id/imageView9"
+        tools:layout_constraintLeft_creator="1"
+        tools:layout_constraintRight_creator="1"
+        tools:layout_editor_absoluteX="96dp" />
+
+    <ImageView
+        android:id="@+id/imageView8"
+        style="@style/Item.12"
+        android:layout_width="96dp"
+        android:layout_height="96dp"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintLeft_toLeftOf="@id/imageView11"
+        app:layout_constraintRight_toRightOf="@id/imageView11"
+        app:layout_constraintTop_toBottomOf="@id/imageView11"
+        tools:layout_constraintLeft_creator="1"
+        tools:layout_constraintRight_creator="1"
+        tools:layout_constraintTop_creator="1"
+        tools:layout_editor_absoluteX="192dp"
+        tools:layout_editor_absoluteY="96dp" />
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/constraint_layout_no_infere.xml
+++ b/app/src/main/res/layout/constraint_layout_no_infere.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/constraintLayout"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    tools:ignore="ContentDescription,RtlHardcoded">
+
+    <ImageView
+        style="@style/Item.00"
+        android:layout_width="96dp"
+        android:layout_height="96dp"
+        android:id="@+id/imageView7"
+        app:layout_constraintLeft_toLeftOf="@+id/constraintLayout"
+        app:layout_constraintTop_toTopOf="@+id/constraintLayout" />
+
+    <ImageView
+        android:id="@+id/imageView9"
+        style="@style/Item.01"
+        android:layout_width="96dp"
+        android:layout_height="96dp"
+        app:layout_constraintLeft_toRightOf="@+id/imageView7"
+        app:layout_constraintTop_toTopOf="@+id/constraintLayout" />
+
+    <ImageView
+        android:id="@+id/imageView11"
+        style="@style/Item.02"
+        android:layout_width="96dp"
+        android:layout_height="96dp"
+        app:layout_constraintLeft_toRightOf="@+id/imageView9"
+        app:layout_constraintTop_toTopOf="@+id/constraintLayout" />
+
+    <ImageView
+        android:id="@+id/imageView10"
+        style="@style/Item.10"
+        android:layout_width="96dp"
+        android:layout_height="96dp"
+        app:layout_constraintLeft_toLeftOf="@+id/constraintLayout"
+        app:layout_constraintTop_toBottomOf="@+id/imageView7" />
+
+    <ImageView
+        android:id="@id/imageView7"
+        style="@style/Item.11"
+        android:layout_width="96dp"
+        android:layout_height="96dp"
+        app:layout_constraintLeft_toRightOf="@+id/imageView10"
+        app:layout_constraintTop_toBottomOf="@+id/imageView9" />
+
+    <ImageView
+        android:id="@+id/imageView8"
+        style="@style/Item.12"
+        android:layout_width="96dp"
+        android:layout_height="96dp"
+        app:layout_constraintTop_toBottomOf="@+id/imageView11"
+        app:layout_constraintRight_toRightOf="@+id/imageView11" />
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/flexbox_layout.xml
+++ b/app/src/main/res/layout/flexbox_layout.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    app:flexWrap="wrap"
+    tools:ignore="ContentDescription,RtlHardcoded">
+
+    <ImageView style="@style/Item.00" />
+
+    <ImageView style="@style/Item.01" />
+
+    <ImageView style="@style/Item.02" />
+
+    <ImageView
+        style="@style/Item.10"
+        app:layout_wrapBefore="true" />
+
+    <ImageView style="@style/Item.11" />
+
+    <ImageView style="@style/Item.12" />
+
+</com.google.android.flexbox.FlexboxLayout>

--- a/app/src/main/res/layout/fragment_content.xml
+++ b/app/src/main/res/layout/fragment_content.xml
@@ -1,14 +1,76 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
     android:gravity="center_horizontal"
-    >
+    android:orientation="vertical"
+    tools:ignore="ContentDescription,RtlHardcoded,HardcodedText">
 
-    <include layout="@layout/frame_layout" />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:padding="16dp">
 
-    <include layout="@layout/linear_layout" />
+        <TextView
+            style="@style/DefaultTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Frame" />
 
-</LinearLayout>
+        <include layout="@layout/frame_layout" />
+
+        <TextView
+            style="@style/DefaultTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Linear" />
+
+        <include layout="@layout/linear_layout" />
+
+        <TextView
+            style="@style/DefaultTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Relative" />
+
+        <include layout="@layout/relative_layout" />
+
+        <TextView
+            style="@style/DefaultTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Table" />
+
+        <include layout="@layout/table_layout" />
+
+        <TextView
+            style="@style/DefaultTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Constraint" />
+
+        <include layout="@layout/constraint_layout_no_infere" />
+
+        <TextView
+            style="@style/DefaultTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Constraint Infere" />
+
+        <include layout="@layout/constraint_layout" />
+
+        <TextView
+            style="@style/DefaultTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Flex" />
+
+        <include layout="@layout/flexbox_layout" />
+
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/relative_layout.xml
+++ b/app/src/main/res/layout/relative_layout.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="ContentDescription,RtlHardcoded"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent">
+
+    <ImageView style="@style/Item.00"
+        android:id="@+id/imageView" />
+
+    <ImageView
+        style="@style/Item.01"
+        android:id="@+id/imageView6"
+        android:layout_alignParentTop="true"
+        android:layout_toRightOf="@+id/imageView"
+        android:layout_toEndOf="@+id/imageView" />
+
+    <ImageView
+        style="@style/Item.02"
+        android:id="@+id/imageView5"
+        android:layout_alignParentTop="true"
+        android:layout_toRightOf="@+id/imageView6"
+        android:layout_toEndOf="@+id/imageView6" />
+
+    <ImageView
+        style="@style/Item.10"
+        android:id="@+id/imageView4"
+        android:layout_below="@+id/imageView"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true" />
+
+    <ImageView
+        style="@style/Item.11"
+        android:id="@+id/imageView3"
+        android:layout_below="@+id/imageView6"
+        android:layout_toRightOf="@+id/imageView4"
+        android:layout_toEndOf="@+id/imageView4" />
+
+    <ImageView
+        style="@style/Item.12"
+        android:id="@+id/imageView2"
+        android:layout_below="@+id/imageView6"
+        android:layout_toRightOf="@+id/imageView6"
+        android:layout_toEndOf="@+id/imageView6" />
+</RelativeLayout>

--- a/app/src/main/res/layout/table_layout.xml
+++ b/app/src/main/res/layout/table_layout.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent">
+
+    <TableRow>
+
+        <ImageView
+            android:id="@+id/imageView"
+            style="@style/Item.00" />
+
+        <ImageView
+            android:id="@+id/imageView6"
+            style="@style/Item.01" />
+
+        <ImageView
+            android:id="@+id/imageView5"
+            style="@style/Item.02" />
+
+    </TableRow>
+
+    <TableRow>
+
+        <ImageView
+            android:id="@+id/imageView4"
+            style="@style/Item.10" />
+
+        <ImageView
+            android:id="@+id/imageView3"
+            style="@style/Item.11" />
+
+        <ImageView
+            android:id="@+id/imageView2"
+            style="@style/Item.12" />
+
+    </TableRow>
+
+
+</TableLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -17,6 +17,12 @@
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
+    <style name="DefaultTextView">
+        <item name="android:gravity">center</item>
+        <item name="android:textSize">20sp</item>
+        <item name="android:textColor">@color/black</item>
+    </style>
+
     <style name="Item">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
@@ -26,22 +32,27 @@
         <item name="srcCompat">@drawable/ic_fast_rewind</item>
         <item name="android:src">@drawable/ic_fast_rewind</item>
     </style>
+
     <style name="Item.01">
         <item name="srcCompat">@drawable/ic_play_circle_filled</item>
         <item name="android:src">@drawable/ic_play_circle_filled</item>
     </style>
+
     <style name="Item.02">
         <item name="srcCompat">@drawable/ic_fast_forward</item>
         <item name="android:src">@drawable/ic_fast_forward</item>
     </style>
+
     <style name="Item.10">
         <item name="srcCompat">@drawable/ic_repeat</item>
         <item name="android:src">@drawable/ic_repeat</item>
     </style>
+
     <style name="Item.11">
         <item name="srcCompat">@drawable/ic_equalizer</item>
         <item name="android:src">@drawable/ic_equalizer</item>
     </style>
+
     <style name="Item.12">
         <item name="srcCompat">@drawable/ic_shuffle</item>
         <item name="android:src">@drawable/ic_shuffle</item>

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven { url "https://jitpack.io" }
     }
 
     // Workaround to prevent Gradle from stealing focus from other apps during tests run/etc.

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -23,6 +23,8 @@ ext.versions = [
         supportLibs                  : '23.4.0',
         butterKnife                  : '8.0.1',
         timber                       : '4.1.2',
+        constraintLayout             : '1.0.0-alpha3',
+        flexbox                      : '0.2.2',
 
         espresso                     : '2.2.1',
         stetho                       : '1.3.1',
@@ -30,6 +32,7 @@ ext.versions = [
         tinyDancer                   : '0.0.8',
         lynx                         : '1.6',
         processPhoenix               : '1.0.2',
+        viewServer                   : '017c01cd51',
 
         junit                        : '4.12',
         robolectric                  : '3.0',
@@ -52,37 +55,40 @@ ext.gradlePlugins = [
 ]
 
 ext.libraries = [
-        dagger                  : "com.google.dagger:dagger:$versions.dagger",
-        daggerCompiler          : "com.google.dagger:dagger-compiler:$versions.dagger",
+        dagger             : "com.google.dagger:dagger:$versions.dagger",
+        daggerCompiler     : "com.google.dagger:dagger-compiler:$versions.dagger",
 
-        autoValue               : "com.google.auto.value:auto-value:$versions.autoValue",
+        autoValue          : "com.google.auto.value:auto-value:$versions.autoValue",
 
-        supportAnnotations      : "com.android.support:support-annotations:$versions.supportLibs",
-        supportAppCompat        : "com.android.support:appcompat-v7:$versions.supportLibs",
-        supportDesign           : "com.android.support:design:$versions.supportLibs",
-        supportRecyclerView     : "com.android.support:recyclerview-v7:$versions.supportLibs",
-        supportCardView         : "com.android.support:cardview-v7:$versions.supportLibs",
+        supportAnnotations : "com.android.support:support-annotations:$versions.supportLibs",
+        supportAppCompat   : "com.android.support:appcompat-v7:$versions.supportLibs",
+        supportDesign      : "com.android.support:design:$versions.supportLibs",
+        supportRecyclerView: "com.android.support:recyclerview-v7:$versions.supportLibs",
+        supportCardView    : "com.android.support:cardview-v7:$versions.supportLibs",
+        constraintLayout   : "com.android.support.constraint:constraint-layout:$versions.constraintLayout",
+        flexboxLayout      : "com.google.android:flexbox:$versions.flexbox",
 
-        butterKnife             : "com.jakewharton:butterknife:$versions.butterKnife",
-        butterKnifeCompiler     : "com.jakewharton:butterknife-compiler:$versions.butterKnife",
-        timber                  : "com.jakewharton.timber:timber:$versions.timber",
+        butterKnife        : "com.jakewharton:butterknife:$versions.butterKnife",
+        butterKnifeCompiler: "com.jakewharton:butterknife-compiler:$versions.butterKnife",
+        timber             : "com.jakewharton.timber:timber:$versions.timber",
+        viewServer         : "com.github.romainguy:ViewServer:$versions.viewServer",
 
         // Developer Tools
-        stetho                  : "com.facebook.stetho:stetho:$versions.stetho",
-        leakCanary              : "com.squareup.leakcanary:leakcanary-android:$versions.leakCanary",
-        tinyDancer              : "com.github.brianPlummer:tinydancer:$versions.tinyDancer",
-        lynx                    : "com.github.pedrovgs:lynx:$versions.lynx",
-        devMetricsNoOp          : "com.frogermcs.androiddevmetrics:androiddevmetrics-runtime-noop:$versions.androidDevMetricsGradlePlugin",
-        processPhoenix          : "com.jakewharton:process-phoenix:$versions.processPhoenix",
+        stetho             : "com.facebook.stetho:stetho:$versions.stetho",
+        leakCanary         : "com.squareup.leakcanary:leakcanary-android:$versions.leakCanary",
+        tinyDancer         : "com.github.brianPlummer:tinydancer:$versions.tinyDancer",
+        lynx               : "com.github.pedrovgs:lynx:$versions.lynx",
+        devMetricsNoOp     : "com.frogermcs.androiddevmetrics:androiddevmetrics-runtime-noop:$versions.androidDevMetricsGradlePlugin",
+        processPhoenix     : "com.jakewharton:process-phoenix:$versions.processPhoenix",
 
         // Test dependencies
-        junit                   : "junit:junit:$versions.junit",
-        robolectric             : "org.robolectric:robolectric:$versions.robolectric",
-        assertJ                 : "org.assertj:assertj-core:$versions.assertJ",
-        equalsVerifier          : "nl.jqno.equalsverifier:equalsverifier:$versions.equalsVerifier",
-        mockitoCore             : "org.mockito:mockito-core:$versions.mockito",
-        supportTestRunner       : "com.android.support.test:runner:$versions.supportTestRunner",
-        supportTestRules        : "com.android.support.test:rules:$versions.supportTestRunner",
-        espressoCore            : "com.android.support.test.espresso:espresso-core:$versions.espresso",
-        espressoContrib         : "com.android.support.test.espresso:espresso-contrib:$versions.espresso",
+        junit              : "junit:junit:$versions.junit",
+        robolectric        : "org.robolectric:robolectric:$versions.robolectric",
+        assertJ            : "org.assertj:assertj-core:$versions.assertJ",
+        equalsVerifier     : "nl.jqno.equalsverifier:equalsverifier:$versions.equalsVerifier",
+        mockitoCore        : "org.mockito:mockito-core:$versions.mockito",
+        supportTestRunner  : "com.android.support.test:runner:$versions.supportTestRunner",
+        supportTestRules   : "com.android.support.test:rules:$versions.supportTestRunner",
+        espressoCore       : "com.android.support.test.espresso:espresso-core:$versions.espresso",
+        espressoContrib    : "com.android.support.test.espresso:espresso-contrib:$versions.espresso",
 ]


### PR DESCRIPTION
|  | Measure (ms) | Layout (ms) | Draw (ms) |
| --- | --- | --- | --- |
| FrameLayout | 0.1-0.3 | 0.03-0.1 | 7-16 |
| LinearLayout | 0.1-0.3 | 0.03-0.1 | 7-16 |
| RelativeLayout | 0.1-0.3 | 0.02-0.06 | 7-16 |
| TableLayout | 0.1-0.3 | 0.04-0.12 | 7-16 |
| ConstrainLayout | 2.0-8.0 | 0.04-0.09 | 8-18 |
| ConstraintLayout (infere) | 2.0-8.0 | 0.04-0.09 | 8-18 |
| FlexboxLayout | 0.5-0.8 | 0.05-0.1 | 10-14 |

В результате измерений выяснилось, что measure ConstraintLayout проходит значительно дольше, чем у остальных видов контейнеров. Я сделала 2 вида ConstraintLayout, один с автоматически сгенерированными констрейнтами, другой - с минимальным количеством, проставленных вручную. В случае автоматического построения количество сгенерированного кода было больше + пришлось дополнительно настраивать лэйаут для корректного отображения. Но на количество времени это не повлияло.

Могу предположить, что несмотря на большую длительность Measure-этапа, это время будет расти медленнее, чем у вложенных друг в друга лэйаутов, поэтому стоит использовать ConstrainLayout для отрисовки сложных интерфейсов.
